### PR TITLE
update converge api urls

### DIFF
--- a/src/ConvergeApi.php
+++ b/src/ConvergeApi.php
@@ -83,9 +83,9 @@ class ConvergeApi
 
         // Set request
         if ($this->live) {
-            $request_url = 'https://www.myvirtualmerchant.com/VirtualMerchant/process.do';
+            $request_url = 'https://api.convergepay.com/VirtualMerchant/process.do';
         } else {
-            $request_url = 'https://demo.myvirtualmerchant.com/VirtualMerchantDemo/process.do';
+            $request_url = 'https://api.demo.convergepay.com/VirtualMerchantDemo/process.do';
         }
 
         // Debugging output


### PR DESCRIPTION
updated api urls as reported in http://www.besha2ready.com/converge
These new urls need to be used starting 10/2016 and will forward to the old urls until then.
BTW thank you for writing this library!
